### PR TITLE
[Feat] Splash 페이지 구현

### DIFF
--- a/src/pages/SnsLoginPage/SnsLoginPage.jsx
+++ b/src/pages/SnsLoginPage/SnsLoginPage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const SnsLoginPage = () => {
+  return (
+    <>
+    <h1>sns로그인페이지임</h1>
+    </>
+  )
+}
+
+export default SnsLoginPage;

--- a/src/pages/SplashPage/SplashPage.jsx
+++ b/src/pages/SplashPage/SplashPage.jsx
@@ -1,0 +1,54 @@
+import { React, useState, useEffect } from 'react';
+import styled from 'styled-components';
+import SplashLogo from '../../assets/images/full-logo.svg'
+import SplashTitle from '../../assets/images/main-title.svg';
+
+import SnsLoginPage from '../../pages/SnsLoginPage/SnsLoginPage';
+
+const SplashPage = () => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+    }, 2500);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  
+  return isLoading ? (
+    <>
+    <SplashScreen>
+    <MainLogo src={SplashLogo} alt="들숨날숨 로고"/>
+    <MainTitle src={SplashTitle} alt="들숨날숨"/>
+    </SplashScreen>
+    </>
+  ) : (
+    <SnsLoginPage />
+  )
+}
+
+export default SplashPage;
+
+const SplashScreen = styled.main`
+display: flex;
+flex-direction: column;
+align-items: center;
+top: 50%;
+left: 50%;
+position: absolute;
+transform: translate(-50%, -50%);
+`
+
+const MainLogo = styled.img`
+display: block;
+width: 20rem;
+height: 20rem;
+margin-bottom: 3rem;
+`
+
+const MainTitle = styled.img`
+width: 17rem;
+height: 6rem;
+`


### PR DESCRIPTION
## 🎽 무엇을 위한 PR인가요?
- [x] 기능 추가 : Splash 페이지 구현


## ⛅ 기대 결과
- useEffect를 사용하여 2.5초 후에 로딩 상태를 비활성화하고 SnsLogin 페이지로 이동한다

## 🌬️ 전달 사항
- 이부분도 로그인 페이지랑 연결해서 토큰이 있으면 로그인 페이지로 이동하지 않고 피드페이지로 이동하게끔 리팩토링이 이루어질 것 같습니다.. ㅎ

## 📝 관련 이슈
- Close : #{31}