### PR TITLE
[Refactor] Footer TabMenu 위치 고정

### DIFF
--- a/src/components/Footer/TabMenu.jsx
+++ b/src/components/Footer/TabMenu.jsx
@@ -51,8 +51,9 @@ const TabMenu = () => {
 export default TabMenu;
 
 const Container = styled.div`
-  position: sticky;
+  position: fixed;
   bottom: 0;
+  width: 39rem;
   display: flex;
   justify-content: space-around;
   border-top: 1px solid ${Theme.colors.borderColor};


### PR DESCRIPTION
## 🎽 무엇을 위한 PR인가요?
- [x] 리팩토링 : `position` , `width` 값 지정

## ⛅ 기대 결과
- 불러올 데이터가 많아도 위치를 고정
<img src="https://github.com/FRONTENDSCHOOL5/final-17-breath-connect/assets/106927728/2340644e-aaf2-430f-8d67-18ef6339b131" width="300">

## 🌬️ 전달 사항
- 페이지 확인하고 TabMenu가 이상하다면 꼭 공유해주세요!