### PR TITLE
[Refactor] 검색 페이지 기능 개선

### DIFF
--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -14,6 +14,7 @@ const SearchPage = () => {
   const [data, setData] = useState([]);
   const [search, setSearch] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const numberRegex = /^https:\/\/api\.mandarin\.weniv\.co\.kr\/[\w.]+$/;
 
   const getSearchResult = async () => {
     const req = await fetch(`${url}/user/searchuser/?keyword=${search}`, {
@@ -25,17 +26,17 @@ const SearchPage = () => {
     });
 
     const res = await req.json();
-    console.log(res);
-    setData(res.slice(0, 10));
+    setData(res.slice(0, 9));
     setIsLoading(false);
   };
 
-  console.log(data);
 
-  const handleProfileClick = (e) => {
-    navigate(`/profile/${data[0].accountname}`, {
-      state: { data: data[0] },
-    });
+  const handleProfileClick = (index) => {
+    if (data && data[index]) {
+      navigate(`/profile/${data[index].accountname}`, {
+        state: { data: data[index] },
+      });
+    }
   };
 
   useEffect(() => {
@@ -47,19 +48,17 @@ const SearchPage = () => {
     getSearchResult();
   }, [search]);
 
-  console.log(data);
-
   return (
     <>
       <TopSearchNavHeader value={search} setValue={setSearch} />
-
       <SearchContainer>
         {data.length === 0 ? (
           <NoResultsText>검색 결과가 없습니다.</NoResultsText>
         ) : (
-          data.map((item) => (
-            <SearchResultItem key={item.id} onClick={handleProfileClick}>
-              <ProfileImage src={profileImg} alt="프로필 이미지" />
+          data.map((item, index) => (
+            <SearchResultItem key={item.id} onClick={() => {handleProfileClick(index)}}>
+              <ProfileImage
+                src={(numberRegex.test(item.image) || item.image === "https://api.mandarin.weniv.co.kr/undefined") ? item.image : profileImg} alt="프로필 이미지"/>
               <UserInfo>
                 <Username>{highlightText(item.username, search)}</Username>
                 <Nickname>{'@' + item.accountname}</Nickname>
@@ -87,23 +86,24 @@ const NoResultsText = styled.p`
 const SearchResultItem = styled.button`
   display: flex;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
 `;
 
 const ProfileImage = styled.img`
   width: 5rem;
   height: 5rem;
   border-radius: 50%;
-  margin-right: 1rem;
+  margin-right: 1.2rem;
 `;
 
 const UserInfo = styled.div`
   display: flex;
   flex-direction: column;
+  text-align: start;
 `;
 
 const Username = styled.p`
-  font-size: 1.4rem;
+  font-size: ${({ theme }) => theme.fontSize.medium};
   margin-bottom: 0.6rem;
   color: ${({ theme }) => theme.colors.blackText};
 `;
@@ -114,7 +114,7 @@ const HighlightedText = styled.span`
 `;
 
 const Nickname = styled.p`
-  font-size: 1.2rem;
+  font-size: ${({ theme }) => theme.fontSize.small};
 `;
 
 const highlightText = (text, search) => {


### PR DESCRIPTION
## 🎽 무엇을 위한 PR인가요?
- [x] 기능 추가 :
- 순서와 상관없이 프로필을 클릭했을 때 정상적으로 프로필 화면으로 이동하는 기능
- 액박 및 프로필 사진 없는 경우, 기본 프로필 사진으로 출력되는 기능
- [x] 스타일 :
- 프로필 사진 및 계정 기타 간격 수정
- [x] 기타 : 
- 데이터 9개만 불러오기

## ⛅ 기대 결과
<img src="https://github.com/FRONTENDSCHOOL5/final-17-breath-connect/assets/106927728/6c58c415-23c2-4423-a5d9-01267d8cdc64" width="320">

## 🌬️ 전달 사항
- 이슈에 추후 진행했으면 하는 기능 추가했습니다.
