### PR TITLE
[Refactor] 상세 페이지 댓글 이미지 URL 미포함 시 기본 이미지 설정

### DIFF
--- a/src/pages/FeedPage/FeedComment.jsx
+++ b/src/pages/FeedPage/FeedComment.jsx
@@ -4,17 +4,26 @@ import BasicProfile from '../../assets/images/basic-profile-xs.svg';
 
 const FeedComment = ({ user, content, image, time }) => {
 
+  const URL = 'https://api.mandarin.weniv.co.kr/';
   const createdTime = () => {
     const year = time.slice(0, 4) + '년 ';
     const month = time.slice(5, 7) + '월 ';
     const date = time.slice(8, 10) + '일';
     return year + month + date;
   }
+
+  const imagePrev = () => {
+    if(!image.includes(URL)) {
+      return BasicProfile
+    } else {
+      return image
+    }
+  }
   
   return (
     <Container>
       <div>
-        <img src={image} alt="유저 프로필 이미지" />
+        <img src={imagePrev()} alt="유저 프로필 이미지" />
       </div>
       <UserContents>
         <UserInfo>


### PR DESCRIPTION
## 🎽 무엇을 위한 PR인가요?
- [x] 리팩토링 : 상세 페이지 댓글 이미지에 URL이 포함되어있지 않으면 기본 이미지로 설정

## ⛅ 기대 결과
- 상세 페이지 댓글 이미지 src에 https://api.mandarin.weniv.co.kr이 포함되어 있어야 한다


## 🌬️ 전달 사항
- 

## 📝 관련 이슈
- Close : #{136}