### PR TITLE
[Fix] 회원가입 이메일 중복 확인 시, 입력값마다 api 함수 호출 에러

### DIFF
--- a/src/pages/ProfileSettingPage/ProfileSettingPage.jsx
+++ b/src/pages/ProfileSettingPage/ProfileSettingPage.jsx
@@ -43,6 +43,11 @@ const ProfileSettingPage = () => {
   setImage(URL + '/' + imgData.filename);
   };
 
+  const handleInputChange = (e) => {
+    const intro = e.target.value;
+    setIntro(intro);
+  }
+
   // username 유효성 검사
   const handleInputUsername = (e) => {
     const username = e.target.value;
@@ -86,11 +91,11 @@ const handleInputAccountname = async (e) => {
 
   /* 에러 메시지 초기화 */
   useEffect(() => {
-    setUsernameErrorMsg();
+    setUsernameErrorMsg('');
   }, [username]);
 
   useEffect(() => {
-    setAccountnameErrorMsg()
+    setAccountnameErrorMsg('')
   }, [accountname]);
 
 const handleProfileSignup = async (e) => {
@@ -158,12 +163,12 @@ const handleProfileSignup = async (e) => {
           id='intro'
           type='text'
           name='intro'
+          onChange={handleInputChange}
           required
         />
         </div>
         <ButtonContainer type={'L'} text={'들숨날숨 시작하기'} isDisabled = {!handleActivateButton()} 
         handleClick={handleProfileSignup}/>
-       
         </UploadForm>
          </ProfileSettingSection>
         </>
@@ -230,7 +235,7 @@ const UploadForm = styled.form`
 const ProfileImage = styled.img`
 width: 100%;
 height: 100%;
-object-fit: contain;
+object-fit: cover;
 border-radius: 50%;
 `
 

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -13,13 +13,14 @@ const SignupPage = () => {
   const [userEmail, setUserEmail] = useState('');
   const [userPassword, setUserPassword] = useState('');
   const [emailErrorMsg, setEmailErrorMsg] = useState('');
+  const [emailSuccessMsg, setEmailSuccessMsg] = useState('');
   const [passwordErrorMsg, setPasswordErrorMsg] = useState('');
   const [emailValid, setEmailValid] = useState(false);
   const [passwordValid, setPasswordValid] = useState(false);
   const [isComplete, setIsComplete] = useState(false);
 
   /* 이메일 유효성 검사 */
-  const handleInputEmail = (e) => {
+  const handleInputEmail = async (e) => {
     const userEmail = e.target.value;
     const emailRegex = 
     /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
@@ -32,17 +33,18 @@ const SignupPage = () => {
       setEmailErrorMsg('');
       setUserEmail(userEmail);
     }
+    
   }
 
 /* 중복된 이메일 확인 */
   const handleEmailDuplicate = async (e) => {
-    const checkEmail = await postEmailDuplicate(e.target.value);
-    console.log(checkEmail);
+    const checkEmail = await postEmailDuplicate(userEmail);
     if (checkEmail.message === '이미 가입된 이메일 주소 입니다.') {
       setEmailErrorMsg('*이미 가입된 이메일 주소 입니다 😥');
     } else if (checkEmail.message === '사용 가능한 이메일 입니다.') {
       setEmailValid(true);
-      setEmailErrorMsg('사용 가능한 이메일 입니다 🤗')
+      setEmailErrorMsg('');
+      setEmailSuccessMsg('사용 가능한 이메일 입니다 🤗');
     }
   }
 
@@ -107,7 +109,8 @@ const SignupPage = () => {
           hasError={emailErrorMsg !== ''}
           required
         />
-        {emailErrorMsg && <ErrorMsg>{emailErrorMsg}</ErrorMsg>}
+        {emailErrorMsg && <ErrorMsg hasError>{emailErrorMsg}</ErrorMsg>}
+        {emailSuccessMsg && <ErrorMsg className="success-msg">{emailSuccessMsg}</ErrorMsg>}
         <div className='input-wrapper'>
         <Input
           label='비밀번호'
@@ -155,5 +158,8 @@ const ErrorMsg = styled.p`
   `}
   &.password-msg {
     margin: -2.4rem 0 3rem;
+  }
+  &.success-msg {
+    color: blue;
   }
 `;

--- a/src/utils/Apis.js
+++ b/src/utils/Apis.js
@@ -31,8 +31,8 @@ export const authInstance = axios.create({
 export const postUserLogin = async (email, password) => {
   const loginData = {
     user: {
-      email,
-      password,
+      email: email,
+      password: password,
     },
   };
   const response = await instance.post('/user/login', loginData);
@@ -43,7 +43,7 @@ export const postUserLogin = async (email, password) => {
 export const postEmailDuplicate = async (email) => {
   const emailData = {
     user: {
-      email,
+      email: email,
     },
   };
   const response = await instance.post('/user/emailvalid', emailData);
@@ -61,12 +61,12 @@ export const postUserSignup = async (
 ) => {
   const userData = {
     user: {
-      username,
-      email,
-      password,
-      accountname,
-      intro,
-      image,
+      username: username,
+      email: email,
+      password: password,
+      accountname: accountname,
+      intro: intro,
+      image: image,
     },
   };
   const response = await instance.post('/user/', userData);


### PR DESCRIPTION
## 🎽 무엇을 위한 PR인가요? 
- [x] 버그 수정 : 이메일 중복 검사를 하는 함수에서 이메일 입력값을 이벤트 요소로 전달하여 이벤트가 발생할 때마다 이메일 중복 검사 함수가 호출되는 오류가 발생했다..!


## ⛅ 기대 결과
- 이메일 중복 검사가 계속 호출되지 않도록 하고, 이메일 중복 검사에 통과했다면 사용 가능한 메시지가 잘 출력되고 validation에 통과되었다면 animation이 작동하지 않도록 한다


## 🌬️ 전달 사항
- api 명세를 보고 데이터를 키, 벨류 값으로 전달해주어서 이부분도 수정했습니다!

## 📝 관련 이슈
- Close : #{172}