### PR TITLE
[Fix] 페이지 전환 시, 로딩 컴포넌트가 렌더링 되지 않는 오류 해결

### DIFF
--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -1,12 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import Modal from '../../components/common/Modal/PostModal';
 import IconPostModal from '../../components/common/Modal/IconPostModal';
-import {
-  reportUserPost,
-  sharePost,
-} from '../../components/common/Modal/ModalFunction';
+import { reportUserPost, sharePost } from '../../components/common/Modal/ModalFunction';
 import Loading from '../../components/common/Loading/Loading';
 import Header from '../../components/Header/TopMainNavHeader';
 import Footer from '../../components/Footer/TabMenu';
@@ -14,43 +10,47 @@ import PostPage from '../PostPage/PostPage';
 import FeedNoUser from './FeedNoUser';
 import { isDarkModeState } from '../../atoms/StylesAtom';
 import { getFollowFeed } from '../../api/post';
-import {Container, Section} from './FeedPageStyle'
+import { Container, Section } from './FeedPageStyle'
 
 const FeedPage = ({ theme }) => {
+  const [isLoading, setIsLoading] = useState(true);
   const [data, setData] = useState([]);
   const [skip, setSkip] = useState(0);
-  const [limit, setLimit] = useState(5);
-  const [isFetchingData, setIsFetchingData] = useState(false);
+  const limit = 5
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalText, setModalText] = useState([]);
   const [modalFunc, setModalFunc] = useState([]);
   const [pickedPost, setPickedPost] = useState('');
-  const location = useLocation();
   const isDarkMode = useRecoilValue(isDarkModeState);
-  const loginData = location.state?.token || localStorage.getItem('token');
+  const userToken = localStorage.getItem('token');
+  
   const fetchData = async () => {
-    if (isFetchingData) return;
-    setIsFetchingData(true);
-    const newData = await getFollowFeed(limit, skip, loginData);
+    try {
+      const newData = await getFollowFeed(limit, skip, userToken);
+      setIsLoading(false);
     if (newData.length > 0) {
       setData((prevData) => [...prevData, ...newData]);
       setSkip((prevSkip) => prevSkip + limit);
     }
-    setIsFetchingData(false);
-  };
+   } catch (error) {
+      console.log(error);
+    }
+  }
 
   useEffect(() => {
     fetchData();
-  }, [loginData]);
+  }, [userToken]);
 
-  useEffect(() => {
-    const handleScroll = () => {
-      const { scrollTop, scrollHeight, clientHeight } =
-        document.documentElement;
-      if (scrollTop + clientHeight >= scrollHeight - 10) {
+  const handleScroll = () => {
+    const scrollHeight = document.documentElement.scrollHeight;
+    const scrollTop = document.documentElement.scrollTop;
+    const clientHeight = document.documentElement.clientHeight;
+    if (scrollTop + clientHeight >= scrollHeight) {
         fetchData();
       }
     };
+
+  useEffect(() => {
     window.addEventListener('scroll', handleScroll);
     return () => {
       window.removeEventListener('scroll', handleScroll);
@@ -62,47 +62,49 @@ const FeedPage = ({ theme }) => {
       setIsModalOpen(true);
       setModalText(['신고', '공유']);
       setModalFunc([
-        () => reportUserPost(loginData, pickedPost),
+        () => reportUserPost(userToken, pickedPost),
         () => sharePost(),
       ]);
     }
   };
 
-  if (!data) {
-    return <Loading />;
-  } else {
-    return (
-        <Container>
-          <Header />
-          <Section>
-          {data.length === 0 ? (
-            <FeedNoUser />
-          ) : (
-            data.map((data, index) => (
-              <PostPage
-                key={index}
-                data={data}
-                showModal={onShowModal}
-                setPickedPost={setPickedPost}
-              />
-            ))
-          )}
-          {isModalOpen && (
-            <Modal setIsModalOpen={setIsModalOpen}>
-              {modalText.map((text, index) => (
-                <IconPostModal
+  return (
+    <Container>
+      <Header />
+      <Section>
+        {isLoading ? (
+          <Loading />
+        ) : (
+          <>
+            {data.length === 0? (
+              <FeedNoUser />
+            ) : (
+              data.map((postData, index) => (
+                <PostPage
                   key={index}
-                  text={text}
-                  onButtonClick={modalFunc[index]}
+                  data={postData}
+                  showModal={() => onShowModal(postData)}
+                  setPickedPost={setPickedPost}
                 />
-              ))}
-            </Modal>
-          )}
-          </Section>
-          <Footer />
-        </Container>
-    );
-  }
+              ))
+            )}
+          </>
+        )}
+        {isModalOpen && (
+          <Modal setIsModalOpen={setIsModalOpen}>
+            {modalText.map((text, index) => (
+              <IconPostModal
+                key={index}
+                text={text}
+                onButtonClick={modalFunc[index]}
+              />
+            ))}
+          </Modal>
+        )}
+      </Section>
+      <Footer />
+    </Container>
+  );
 };
 
 export default FeedPage;

--- a/src/pages/FollowListPage/FollowerListPage/FollowerListPage.jsx
+++ b/src/pages/FollowListPage/FollowerListPage/FollowerListPage.jsx
@@ -4,6 +4,7 @@ import { useRecoilValue } from 'recoil';
 import Follower from '../../../components/common/User/Follow/Follow';
 import Header from '../../../components/Header/TopListNavHeader';
 import Footer from '../../../components/Footer/TabMenu';
+import Loading from '../../../components/common/Loading/Loading';
 import { tokenAtom } from '../../../atoms/UserAtom';
 import { isDarkModeState } from '../../../atoms/StylesAtom';
 import { getFollowerList } from '../../../api/follow';
@@ -23,18 +24,22 @@ const FollowerListPage = ({theme}) => {
   const account = useParams().id;
   const isDarkMode = useRecoilValue(isDarkModeState);
   const token = useRecoilValue(tokenAtom);
+  const [isLoading, setIsLoading] = useState(true);
   const [followings, setFollowings] = useState([]);
   useEffect(() => {
     const followList = async () => {
       // 팔로워 리스트 목록
       const data = await getFollowerList(account);
       setFollowings(data);
+      setIsLoading(false);
     };
     followList();
   }, [account, token]);
 
   return (
-    <Container>
+    <>
+    {isLoading ? <Loading /> : (
+      <Container>
       <Header />
       <Main>
         <Title>팔로워목록</Title>
@@ -62,7 +67,8 @@ const FollowerListPage = ({theme}) => {
         </List>
       </Main>
       <Footer />
-    </Container>
+    </Container>)}
+    </>
   );
 };
 

--- a/src/pages/FollowListPage/FollowingListPage/FollowingListPage.jsx
+++ b/src/pages/FollowListPage/FollowingListPage/FollowingListPage.jsx
@@ -4,6 +4,7 @@ import { useRecoilValue } from 'recoil';
 import Following from '../../../components/common/User/Follow/Follow';
 import Header from '../../../components/Header/TopListNavHeader';
 import Footer from '../../../components/Footer/TabMenu';
+import Loading from '../../../components/common/Loading/Loading';
 import { tokenAtom } from '../../../atoms/UserAtom';
 import { isDarkModeState } from '../../../atoms/StylesAtom';
 import { getFollowingList } from '../../../api/follow';
@@ -24,16 +25,20 @@ const FollowingListPage = ({theme}) => {
   const account = useParams().id;
   const isDarkMode = useRecoilValue(isDarkModeState);
   const token = useRecoilValue(tokenAtom);
+  const [isLoading, setIsLoading] = useState(true);
   const [followings, setFollowings] = useState([]);
   useEffect(() => {
     const followList = async () => {
       const data = await getFollowingList(account);
       setFollowings(data);
+      setIsLoading(false);
     };
     followList();
   }, [account, token]);
 
   return (
+    <>
+    {isLoading ? <Loading /> : (
     <Container>
       <Header />
       <Main>
@@ -62,7 +67,8 @@ const FollowingListPage = ({theme}) => {
         </List>
       </Main>
       <Footer />
-    </Container>
+    </Container>)}
+    </>
   );
 };
 

--- a/src/pages/ProfilePage/ProfileEditPage/ProfileEditPage.jsx
+++ b/src/pages/ProfilePage/ProfileEditPage/ProfileEditPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useRecoilState, useSetRecoilState, useRecoilValue } from 'recoil';
 import Input from '../../../components/common/Input/Input';
 import Header from '../../../components/Header/TopUploadHeader';
+import Loading from '../../../components/common/Loading/Loading';
 import {
   accountAtom,
   profileImgAtom,
@@ -31,6 +32,7 @@ const ProfileEditPage = ({theme}) => {
   const fileInputRef = useRef();
   const formData = new FormData();
 
+  const [isLoading, setIsLoading] = useState(true);
   const [username, setUsername] = useState('');
   const [accountname, setAccountname] = useState('');
   const [intro, setIntro] = useState('');
@@ -50,6 +52,7 @@ const ProfileEditPage = ({theme}) => {
   useEffect(() => {
     const fetchMyInfo = async () => {
       const response = await getMyInfo(userToken);
+      setIsLoading(false);
       setUsername(response.user.username);
       setAccountname(response.user.accountname);
       setIntro(response.user.intro);
@@ -151,7 +154,9 @@ const ProfileEditPage = ({theme}) => {
 
   return (
     <>
-      <Header
+    {isLoading ? <Loading /> : (
+      <>
+    <Header
         text="저장"
         isDisabled={!handleActivateButton()}
         handleClick={handleProfileEdit}
@@ -201,6 +206,9 @@ const ProfileEditPage = ({theme}) => {
           />
         </Form>
       </Container>
+      </>
+      )
+    }
     </>
   );
 };

--- a/src/pages/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage.jsx
@@ -32,6 +32,7 @@ import { Container, Section } from './ProfilePageStyle'
 const ProfilePage = ({ theme }) => {
   const location = useLocation();
   const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(true);
   const [posts, setPosts] = useState([]);
   const [profile, setProfile] = useState();
   const [accountName, setAccountName] = useState('');
@@ -64,6 +65,7 @@ const ProfilePage = ({ theme }) => {
     try {
       await getProfile();
       await getPost();
+      setIsLoading(false);
     } catch (error) {
       console.error('Error fetching user data:', error);
     }
@@ -144,43 +146,42 @@ const ProfilePage = ({ theme }) => {
     }
   };
 
-  if (!posts) {
-    return <Loading />;
-  } else {
-    return (
-        <Container>
-          <Header onButtonClick={onShowHeaderModal} />
-          {profile && (
-            <UserInfo
-              data={profile}
-              myProfile={
-                JSON.parse(localStorage.getItem('recoil-persist'))[
-                  'accountAtom'
-                ] === accountName
-              }
-            />
-          )}
-          <Section>
+   return (
+  <Container>
+    <Header onButtonClick={onShowHeaderModal} />
+    {isLoading? <Loading /> : (
+      <>
+      {profile && (
+          <UserInfo
+            data={profile}
+            myProfile={
+              JSON.parse(localStorage.getItem('recoil-persist'))[
+                'accountAtom'
+              ] === accountName
+            }
+          />
+        )}
+        <Section>
           {posts.length > 0 &&
             posts.map((post, index) => (
               <PostPage key={index} data={post} showModal={onShowModal} />
             ))}
-          </Section>
-          {isModalOpen && (
-            <Modal setIsModalOpen={setIsModalOpen}>
-              {modalText.map((text, index) => (
-                <IconPostModal
-                  key={index}
-                  text={text}
-                  onButtonClick={modalFunc[index]}
-                />
-              ))}
-            </Modal>
-          )}
-          <Footer />
-        </Container>
-    );
-  }
-};
+        </Section>
+        {isModalOpen && (
+          <Modal setIsModalOpen={setIsModalOpen}>
+            {modalText.map((text, index) => (
+              <IconPostModal
+                key={index}
+                text={text}
+                onButtonClick={modalFunc[index]}
+              />
+            ))}
+          </Modal>
+        )}
+        </>
+        )} 
+        <Footer />
+  </Container>
+   )}
 
 export default ProfilePage;


### PR DESCRIPTION
## 🎽 무엇을 위한 PR인가요?
- [ ] 기능 추가 :
- [ ] 스타일 :
- [x] 리팩토링 : api 요청을 하기 전, 로딩 상태일 때 로딩 컴포넌트가 렌더링 되도록 조건부 렌더링을 추가합니다. FeedPage에서 loginData 변수명을 userToken으로 변경합니다.
- [ ] 문서 수정 : 
- [ ] 버그 수정 : 
- [ ] 기타 : 


## ⛅ 기대 결과
- 
![Animation10](https://github.com/FRONTENDSCHOOL5/final-17-breath-connect/assets/80268199/53ea6563-b7aa-4e56-b8d6-d4bc7632ee33)
다음과 같이 페이지 전환을 자연스럽게 하고 느린 네트워크 상황에 대응하기 위해 api 요청으로 응답 받기 전, 로딩 컴포넌트를 렌더링합니다.


## 🌬️ 전달 사항
- 추가적으로 로딩 컴포넌트가 필요한 부분 있으면 말씀해주세요!

## 📝 관련 이슈
- Close : #258 